### PR TITLE
Modernaize

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
   ansible-runner:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,9 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: extract-tag
-        run: echo ::set-output name=DOCKER_TAG::$(echo ${GITHUB_REF#refs/tags/v})
-      - uses: docker/build-push-action@v5
+        run: echo "DOCKER_TAG=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+      - uses: docker/bake-action@v6
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:buildcache,mode=max
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:latest,${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:${{ steps.extract-tag.outputs.DOCKER_TAG }}
+          target: app-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - id: extract-tag
+        run: echo "DOCKER_TAG=test" >> $GITHUB_ENV
+      - uses: docker/bake-action@v6
         with:
-          load: true
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:buildcache,mode=max
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:test
-      - uses: actions/checkout@v4
+          target: app-release
+      - uses: actions/checkout@v6
       - run: docker compose run --rm ansible-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:buildcache,mode=max
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.DOCKER_HUB_IMAGE_NAME }}:test
       - uses: actions/checkout@v4
-      - run: docker compose -f compose.test.yml run --rm sut
+      - run: docker compose run --rm ansible-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Migrated from RedHat, It might be oriented towards closed products
-FROM amazonlinux:2023.4.20240401.1 as production
-RUN dnf update -y && dnf install -y python3.11-3.11.6-1.amzn2023.0.1.x86_64 openssl-3.0.8-1.amzn2023.0.11.x86_64 && dnf clean all
+FROM amazonlinux:2023.4.20240401.1 AS production
+RUN dnf update -y && dnf install -y python3.11-3.11.6-1.amzn2023.0.1 openssl-3.0.8-1.amzn2023.0.11 && dnf clean all
 RUN ln -s /usr/bin/python3.11 /usr/bin/python
 # Do not change what the /usr/bin/python3 symlink points to because this might break the core functionality of AL2023:
 # - Python in AL2023 - Amazon Linux 2023
@@ -27,5 +27,9 @@ COPY runner /runner
 ENV RUNNER_PLAYBOOK=playbook.yml
 VOLUME ["/etc/pki"]
 
-FROM production as development
+FROM production AS development
+# Reason:
+#   DL3013: For development
+#   SC2174: Maybe hadolint's bug
+# hadolint ignore=DL3013,SC2174
 RUN python -m pip install --no-cache-dir ansible-lint

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.6'
 services:
   sut:
     build:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,8 +1,0 @@
----
-services:
-  sut:
-    build:
-      context: .
-      target: production
-    environment:
-      DOMAIN_NAME: exampledomain.com

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   ansible-runner:
     build:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,16 @@
+variable "DOCKER_TAG" {
+}
+target "ansible-runner" {
+  tags = [
+    "futureys/ssl-certificate:latest",
+    "futureys/ssl-certificate:${DOCKER_TAG}",
+  ]
+}
+// To prevent following error when testing `docker buildx bake` in development PC:
+//   ERROR: Multi-platform build is not supported for the docker driver.
+//   Switch to a different driver, or turn on the containerd image store, and try again.
+//   Learn more at https://docs.docker.com/go/build-multi-platform/
+target "app-release" {
+  inherits = ["ansible-runner"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}


### PR DESCRIPTION
This pull request updates the project's Docker and CI/CD workflows to modernize the build process, improve compatibility, and simplify configuration. The main changes involve switching from Docker Compose YAML versioning to Docker Bake, updating GitHub Actions workflows to use the new bake action, and cleaning up legacy or redundant files.

**CI/CD workflow and build process modernization:**

* Updated GitHub Actions workflows (`test.yml` and `deploy.yml`) to use `docker/bake-action@v6` instead of `docker/build-push-action`, targeting the new `app-release` target for multi-platform builds and updating branch references from `master` to `main`. Also updated the test job to use `ansible-runner` directly and switched to `actions/checkout@v6`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R24) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L5-R8) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L22-R27)
* Added a `docker-bake.hcl` file to define build targets (`ansible-runner` and `app-release`) and tags, enabling multi-platform builds and supporting the new bake workflow.

**Dockerfile and container configuration improvements:**

* Updated the `Dockerfile` to use consistent `AS` syntax for build stages, removed architecture suffixes from package names, and added comments and hadolint ignores for development. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L30-R34)

**Docker Compose configuration cleanup:**

* Removed the Compose file version specification (`version: '3.9'` or `'3.6'`) from `compose.yml`, `.devcontainer/compose.yml`, and deleted the legacy `compose.test.yml` file to simplify Docker Compose usage. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L2) [[2]](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43L1) [[3]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L1-L9)