### PR TITLE
Support for root domain as optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,6 @@ jobs:
           target: app-release
       - uses: actions/checkout@v6
       - run: docker compose run --rm ansible-runner
+      - run: docker compose run --rm ansible-runner
+        env:
+          SUPPORT_ROOT_DOMAIN: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ CMD ["ansible-runner", "run", "/runner"]
 COPY runner /runner
 ENV RUNNER_PLAYBOOK=playbook.yml
 VOLUME ["/etc/pki"]
+ENV SUPPORT_ROOT_DOMAIN=false
 
 FROM production AS development
 # Reason:

--- a/compose.yml
+++ b/compose.yml
@@ -6,3 +6,4 @@ services:
       target: production
     environment:
       DOMAIN_NAME: exampledomain.com
+      SUPPORT_ROOT_DOMAIN: ${SUPPORT_ROOT_DOMAIN:-false}

--- a/runner/env/extravars
+++ b/runner/env/extravars
@@ -1,2 +1,3 @@
 ---
 roles_common_domain_name: '{{ lookup("env","DOMAIN_NAME") }}'
+support_root_domain: '{{ lookup("env", "SUPPORT_ROOT_DOMAIN") | default(false) }}'


### PR DESCRIPTION
This pull request introduces support for a new `SUPPORT_ROOT_DOMAIN` environment variable across the deployment and Ansible runner setup. The main goal is to allow configuration of whether the root domain should be supported, with the default set to `false` unless explicitly enabled. This affects the Docker, Compose, GitHub Actions, and Ansible configurations. Additionally, the SSL certificate role submodule has been updated.

**Support for root domain configuration:**

* Added `SUPPORT_ROOT_DOMAIN` environment variable to the `Dockerfile`, defaulting to `false` for greater deployment flexibility.
* Updated `compose.yml` to pass the `SUPPORT_ROOT_DOMAIN` variable to the service environment, allowing it to be set via environment or defaulting to `false`.
* Modified GitHub Actions workflow (`test.yml`) to set `SUPPORT_ROOT_DOMAIN` to `true` during the Ansible runner job, enabling root domain support in CI.
* Updated Ansible runner `extravars` to include the `support_root_domain` variable, sourced from the environment.

**Dependency update:**

* Updated the `ansible-role-ssl-certificate-amazon-linux` submodule to the latest commit, potentially pulling in SSL-related improvements or fixes.