### PR TITLE
Fix bug that arm image isn't deployed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
-          target: app-release
+          targets: app-release


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration, correcting the argument name from `target` to `targets` in the Docker build step.