### PR TITLE
E2e testing

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,6 +1,6 @@
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
-  ansible-runner:
+  ssl-certificate:
     # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
     # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
     # debugging) to execute as the user. Uncomment the next line if you want the entire 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "ansible-runner",
+	"service": "ssl-certificate",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   deploy:
-    env:
-      DOCKER_HUB_IMAGE_NAME: 'ssl-certificate'
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: extract-tag
         run: echo "DOCKER_TAG=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: docker/bake-action@v6
         with:
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,42 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - id: extract-tag
-        run: echo "DOCKER_TAG=test" >> $GITHUB_ENV
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: docker/bake-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          target: app-release
-      - uses: actions/checkout@v6
+          targets: app-release
+        env:
+          DOCKER_TAG: test
+      - uses: docker/bake-action@v6
+        with:
+          load: true
+          builder: ${{ steps.buildx.outputs.name }}
+        env:
+          DOCKER_TAG: test
       - name: Test that running without SUPPORT_ROOT_DOMAIN should succeed
         run: docker compose run --rm ssl-certificate
+      - name: Tear down
+        run: docker compose down -v
+      - name: Test that running with SUPPORT_ROOT_DOMAIN should succeed
+        run: docker compose -f compose.yml -f compose.test.yml run --rm ssl-certificate
+      - name: Tear down
+        run: docker compose -f compose.yml -f compose.test.yml down -v
+      - name: Test that running with SUPPORT_ROOT_DOMAIN should succeed
+        id: test_database
+        run: |
+          CONTAINER_ID=$(docker compose -f compose.yml -f compose.test.yml run -d --rm database mysqld)
+          echo "Started database container with ID: $CONTAINER_ID"
+          timeout 60s docker logs --follow --tail=0 "$CONTAINER_ID" 2>&1 | grep --max-count=1 'ready for connections\.'
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_OUTPUT
+      - name: Debug
+        if: always()
+        run: docker logs ${{ steps.test_database.outputs.CONTAINER_ID }} 2>&1
+      - name: Tear down
+        run: |
+          docker stop ${{ steps.test_database.outputs.CONTAINER_ID }}
+          docker compose -f compose.yml -f compose.test.yml down -v
       - name: Test that SSL certificate should work well
         run: docker compose -f compose.yml -f compose.test.yml run --rm mysql-client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
       - main
 jobs:
   test:
-    env:
-      DOCKER_HUB_IMAGE_NAME: 'ssl-certificate'
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v3
@@ -26,7 +24,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           target: app-release
       - uses: actions/checkout@v6
-      - run: docker compose run --rm ssl-certificate
-      - run: docker compose run --rm ssl-certificate
-        env:
-          SUPPORT_ROOT_DOMAIN: true
+      - name: Test that running without SUPPORT_ROOT_DOMAIN should succeed
+        run: docker compose run --rm ssl-certificate
+      - name: Test that SSL certificate should work well
+        run: docker compose -f compose.yml -f compose.test.yml run --rm mysql-client

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           target: app-release
       - uses: actions/checkout@v6
-      - run: docker compose run --rm ansible-runner
-      - run: docker compose run --rm ansible-runner
+      - run: docker compose run --rm ssl-certificate
+      - run: docker compose run --rm ssl-certificate
         env:
           SUPPORT_ROOT_DOMAIN: true

--- a/README.md
+++ b/README.md
@@ -44,39 +44,57 @@ docker run --env DOMAIN_NAME=exampledomain.com \
            futureys/ssl-certificate
 ```
 
-## ... via docker-compose
+## ... via docker compose
 
 This example is to enable SSL on MySQL database.
 
 1\.
 
-Prepare `docker-compose.yml`:
+Prepare `compose.yml`:
 
 ```yaml
 ---
 services:
   ssl-certificate:
     environment:
-      DOMAIN_NAME: ${DOMAIN_NAME}
+      DOMAIN_NAME: database
+      SUPPORT_ROOT_DOMAIN: true
     image: futureys/ssl-certificate:latest
     volumes:
       - pki:/etc/pki
 
   database:
     command:
-      - --ssl-ca=/etc/pki/CA/cacert-${DOMAIN_NAME}.pem
-      - --ssl-cert=/etc/pki/tls/certs/servercert-${DOMAIN_NAME}.pem
-      - --ssl-key=/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem
+      - --ssl-ca=/etc/pki/CA/cacert-database.pem
+      - --ssl-cert=/etc/pki/tls/certs/servercert-database.pem
+      - --ssl-key=/etc/pki/tls/private/serverkey-database.pem
     depends_on:
-      - ssl-certificate
+      ssl-certificate:
+        condition: service_completed_successfully
     entrypoint: setup-certificate.sh
     environment:
-      DOMAIN_NAME: ${DOMAIN_NAME}
       MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
-    image: mysql
+    healthcheck:
+      test:
+        - CMD
+        - mysqladmin
+        - ping
+        - -h
+        - localhost
+        - -u
+        - root
+        - -pexamplepass
+        - --ssl-mode=REQUIRED
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 30s # Adjust based on your MySQL initialization time
+    image: mysql:9.5.0
     volumes:
+      # To enable SSL for MySQL serving.
       - pki:/etc/pki
       - ./database_entrypoint/setup-certificate.sh:/usr/local/bin/setup-certificate.sh
+      # For MySQL less than 9.0.0 to enable SSL connection enforcement.
       - ./mysql_conf.d:/etc/mysql/conf.d
 
 volumes:
@@ -85,7 +103,7 @@ volumes:
 
 2\.
 
-Prepare `mysql_conf.d/ssl.cnf`:
+If you are using MySQL less than 9.0.0, prepare `mysql_conf.d/ssl.cnf`:
 
 ```ini
 [mysqld]
@@ -99,15 +117,10 @@ Prepare Shell Script `./database_entrypoint/setup-certificate.sh`
 to wait for creating certificate and set appropriate permission to certificate before MySQL start:
 
 ```sh
-#!/usr/bin/env sh
-SERVERCERT="/etc/pki/tls/certs/servercert-${DOMAIN_NAME}.pem"
+set -eu
+
+DOMAIN_NAME=${DOMAIN_NAME-database}
 SERVERKEY="/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem"
-while :; do
-    if [ -r "${SERVERCERT}" ]; then
-        break
-    fi
-    sleep 1
-done
 
 group_database=$([ $(which postgres) ] && echo "postgres" || echo "mysql")
 
@@ -134,12 +147,12 @@ Pick up self signed certificate from shared volume.
 For example, in case when `web` container using volume:
 
 ```console
-docker cp web:/etc/pki/CA/cacert-domain.name.pem ./cacert-domain.name.pem
+docker cp web:/etc/pki/CA/cacert-database.pem ./cacert-database.pem
 ```
 
 2\.
 
-Install `cacert-domain.name.pem` into your browswer.
+Install `cacert-database.pem` into your browser.
 
 cf. [Answer: How do I deal with NET:ERR_CERT_AUTHORITY_INVALID in Chrome?](https://superuser.com/questions/1083766/how-do-i-deal-with-neterr-cert-authority-invalid-in-chrome/1083768#1083768)
 
@@ -148,6 +161,12 @@ cf. [Answer: How do I deal with NET:ERR_CERT_AUTHORITY_INVALID in Chrome?](https
 ### ```DOMAIN_NAME```
 
 Domain name for install SSL certificate.
+
+### ```SUPPORT_ROOT_DOMAIN```
+
+Whether to support root domain for SSL certificate installation.
+Set to `true` to support root domain.
+Default is not to support it.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prepare `docker-compose.yml`:
 ```yaml
 ---
 services:
-  ssl_certificate:
+  ssl-certificate:
     environment:
       DOMAIN_NAME: ${DOMAIN_NAME}
     image: futureys/ssl-certificate:latest
@@ -68,7 +68,7 @@ services:
       - --ssl-cert=/etc/pki/tls/certs/servercert-${DOMAIN_NAME}.pem
       - --ssl-key=/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem
     depends_on:
-      - ssl_certificate
+      - ssl-certificate
     entrypoint: setup-certificate.sh
     environment:
       DOMAIN_NAME: ${DOMAIN_NAME}

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,0 +1,69 @@
+---
+services:
+  # Since the latest version of MySQL is set to use default SSL certificate files,
+  # that SSL certificate isn't able to set CN, we need to create our own SSL certificate files.
+  ssl-certificate:
+    environment:
+      DOMAIN_NAME: database
+      SUPPORT_ROOT_DOMAIN: true
+    volumes:
+      - pki:/etc/pki
+  database:
+    command:
+      - --ssl-ca=/etc/pki/CA/cacert-database.pem
+      - --ssl-cert=/etc/pki/tls/certs/servercert-database.pem
+      - --ssl-key=/etc/pki/tls/private/serverkey-database.pem
+    depends_on:
+      ssl-certificate:
+        condition: service_completed_successfully
+    entrypoint: setup-certificate.sh
+    environment:
+      MYSQL_ROOT_PASSWORD: examplepass
+    healthcheck:
+      test:
+        - CMD
+        - mysqladmin
+        - ping
+        - -h
+        - localhost
+        - -u
+        - root
+        - -pexamplepass
+        - --ssl-mode=REQUIRED
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 30s # Adjust based on your MySQL initialization time
+    image: mysql:9.5.0
+    volumes:
+      # To enable SSL for MySQL serving.
+      - pki:/etc/pki
+      - ./database_entrypoint/setup-certificate.sh:/usr/local/bin/setup-certificate.sh
+
+  mysql-client:
+    build: mysql-client
+    command:
+      - mysql
+      - --ssl-ca=/etc/pki/CA/cacert-database.pem
+      - -h
+      - database
+      - -u
+      - root
+      - -pexamplepass
+      - -e
+      - >-
+        SHOW DATABASES;
+        SHOW GLOBAL VARIABLES LIKE '%ssl%';
+        SHOW SESSION STATUS LIKE 'Ssl_cipher';
+        SELECT User, Host, ssl_type FROM mysql.user;
+        SHOW GLOBAL VARIABLES LIKE 'tls_version';
+    depends_on:
+      database:
+        condition: service_healthy
+      ssl-certificate:
+        condition: service_completed_successfully
+    volumes:
+      # To enable SSL for MySQL serving.
+      - pki:/etc/pki
+volumes:
+  pki:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 ---
 services:
-  ansible-runner:
+  ssl-certificate:
     build:
       context: .
       target: production

--- a/database_entrypoint/setup-certificate.sh
+++ b/database_entrypoint/setup-certificate.sh
@@ -4,7 +4,8 @@ set -eu
 DOMAIN_NAME=${DOMAIN_NAME-database}
 SERVERKEY="/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem"
 
-group_database=$([ $(which postgres) ] && echo "postgres" || echo "mysql")
+# In MySQL Image, which command is not installed
+group_database=$([ $(command -v postgres) ] && echo "postgres" || echo "mysql")
 
 chown "root:${group_database}" "${SERVERKEY}"
 chmod 640 "${SERVERKEY}"

--- a/database_entrypoint/setup-certificate.sh
+++ b/database_entrypoint/setup-certificate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eu
+
+DOMAIN_NAME=${DOMAIN_NAME-database}
+SERVERKEY="/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem"
+
+group_database=$([ $(which postgres) ] && echo "postgres" || echo "mysql")
+
+chown "root:${group_database}" "${SERVERKEY}"
+chmod 640 "${SERVERKEY}"
+# "docker-entrypoint.sh" is default ENTRYPOINT of Docker Hub official database images.
+# see: https://github.com/docker-library/mysql/blob/8e6735541864ab63c98cdf92d3ef498e4c953f3e/8.0/Dockerfile
+# see: https://github.com/docker-library/mysql/blob/8e6735541864ab63c98cdf92d3ef498e4c953f3e/5.7/Dockerfile
+# see: https://github.com/docker-library/mysql/blob/8e6735541864ab63c98cdf92d3ef498e4c953f3e/5.6/Dockerfile
+# see: https://github.com/docker-library/postgres/blob/b80fcb5ac7f6dde712e70d2d53a88bf880700fde/Dockerfile-debian.template
+# see: https://github.com/docker-library/postgres/blob/b80fcb5ac7f6dde712e70d2d53a88bf880700fde/Dockerfile-alpine.template
+exec docker-entrypoint.sh "$@"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,6 @@
 variable "DOCKER_TAG" {
 }
-target "ansible-runner" {
+target "ssl-certificate" {
   tags = [
     "futureys/ssl-certificate:latest",
     "futureys/ssl-certificate:${DOCKER_TAG}",
@@ -11,6 +11,6 @@ target "ansible-runner" {
 //   Switch to a different driver, or turn on the containerd image store, and try again.
 //   Learn more at https://docs.docker.com/go/build-multi-platform/
 target "app-release" {
-  inherits = ["ansible-runner"]
+  inherits = ["ssl-certificate"]
   platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/mysql-client/Dockerfile
+++ b/mysql-client/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:trixie-20251117-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # To set up SSL certificates
+    ca-certificates/stable \
+    default-mysql-client/stable
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint
+ENTRYPOINT ["entrypoint"]

--- a/mysql-client/entrypoint.sh
+++ b/mysql-client/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+
+DOMAIN_NAME=${DOMAIN_NAME-database}
+mkdir -p /usr/local/share/ca-certificates
+cp -p /etc/pki/CA/cacert-${DOMAIN_NAME}.pem /usr/local/share/ca-certificates/cacert-${DOMAIN_NAME}.crt
+update-ca-certificates
+
+exec "${@}"


### PR DESCRIPTION
This pull request refactors the development and test setup to standardize naming conventions around the `ssl-certificate` service, improves documentation and test coverage for MySQL SSL certificate handling, and introduces new scripts and Dockerfiles for better automation and compatibility. The most significant changes are grouped below.

**Development and CI/CD Configuration Updates:**

* Renamed the main service from `ansible-runner` to `ssl-certificate` across `.devcontainer/compose.yml`, `.devcontainer/devcontainer.json`, `compose.yml`, and related workflow files to maintain consistency and clarity. [[1]](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43L3-R3) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L16-R16) [[3]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L3-R3) [[4]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L3-R3) [[5]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L14-R14) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L7-L8) [[7]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L11-L12)
* Updated GitHub Actions test workflow to use the new service name and added a step to test SSL certificate functionality using a new `mysql-client` container. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L29-R30) [[2]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7R1-R69) [[3]](diffhunk://#diff-e7e3818d600249a1097dc67466f424a1c6de6330aa7a133059db7f9a40889975R1-R7) [[4]](diffhunk://#diff-49c5d6ca6724109814c6d225833877b47cc9e3dd0bbf3b784d3ee4893b568c01R1-R9)

**Documentation Improvements:**

* Revised the `README.md` to reflect the new service name, update compose file names and formats, clarify MySQL SSL configuration for different versions, and document the new `SUPPORT_ROOT_DOMAIN` environment variable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R97) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R106) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-L110) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R155) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R170)

**Automation and Compatibility Enhancements:**

* Added a new `database_entrypoint/setup-certificate.sh` script to ensure proper permissions on generated server keys before MySQL starts, improving automation and compatibility with both MySQL and Postgres.
* Introduced a new `mysql-client` Docker image and entrypoint script to automate SSL CA installation and run MySQL client commands for testing SSL connections. [[1]](diffhunk://#diff-e7e3818d600249a1097dc67466f424a1c6de6330aa7a133059db7f9a40889975R1-R7) [[2]](diffhunk://#diff-49c5d6ca6724109814c6d225833877b47cc9e3dd0bbf3b784d3ee4893b568c01R1-R9)

**Test Compose Environment:**

* Added a new `compose.test.yml` to provide a comprehensive test environment for MySQL with SSL, including health checks, certificate sharing, and a dedicated client for validation.